### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class Example
   # if the type doesnt match Rubisierung will raise an Error messages
 
   # add custom Types
-  # [TypeClass, StandartDuckTypeAsSymbol, StrictDuckTypeAsSymbol]# TODO change to proper name
+  # [TypeClass, StandardDuckTypeAsSymbol, StrictDuckTypeAsSymbol]# TODO change to proper name
   @__add_type[CustomType, :to_s, :to_str]
 
   # define foo to respond to :to_s and bar to :to_i

--- a/lib/rubysierung.rb
+++ b/lib/rubysierung.rb
@@ -62,7 +62,7 @@ module Rubysierung
         rescue NoMethodError
           # return argument, param, duck_type, calle/receiver -> file, line
           if strict == 0
-            raise Rubysierung::Error::Standart, "Rubysierung::Error::Standart: Class:#{klass}, DuckType:#{type[2]}, Method:#{@__error_data[:method_object]}:#{@__error_data[:method_file]}#{@__error_data[:method_name]}:#{@__error_data[:method_line]} -- called on #{@__error_data[:caller]} with #{@__error_data[:var_sym]}:#{value} of #{value.class} doesn't respond to #{type[2]}"
+            raise Rubysierung::Error::Standard, "Rubysierung::Error::Standard: Class:#{klass}, DuckType:#{type[2]}, Method:#{@__error_data[:method_object]}:#{@__error_data[:method_file]}#{@__error_data[:method_name]}:#{@__error_data[:method_line]} -- called on #{@__error_data[:caller]} with #{@__error_data[:var_sym]}:#{value} of #{value.class} doesn't respond to #{type[2]}"
           else
             raise Rubysierung::Error::Strict, "Rubysierung::Error::Strict: Class:#{klass}, DuckType:#{type[2]}, Method:#{@__error_data[:method_object]}:#{@__error_data[:method_file]}#{@__error_data[:method_name]}:#{@__error_data[:method_line]} -- called on #{@__error_data[:caller]} with #{@__error_data[:var_sym]}:#{value} of #{value.class} doesn't respond to #{type[2]}"
           end


### PR DESCRIPTION
Hey. This project looks awesome!

One issue is [this line](https://github.com/doodzik/rubysierung/blob/0a9663880b26fdbe7f54270d6a6715812f978ee6/lib/rubysierung.rb#L38), which prevents using `rubysierung` in `irb` (or `pry` or `ruby -e` or any non-file context).

I am also based in Berlin. It might be fun to meet up in-person and hack on this. Let me know if that sounds interesting to you.
